### PR TITLE
Test NIDM Dataset Descriptor at the Project Summary Level

### DIFF
--- a/niquery/sparql/meta.rq
+++ b/niquery/sparql/meta.rq
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX nidm: <http://incf.org/ns/nidash/nidm#>
 PREFIX niq: <http://purl.org/niquery#>
 
-SELECT ?uri ?title ?description ?creator ?format ?downloadURL (GROUP_CONCAT(?keyword;SEPARATOR=";") AS ?keywords) ?model
+SELECT DISTINCT ?uri ?title ?description ?creator ?format ?downloadURL (GROUP_CONCAT(?keyword;SEPARATOR=";") AS ?keywords) ?model
 WHERE {
     ?uri a niq:SelectQuery ;
         dct:title ?title ;
@@ -17,4 +17,4 @@ WHERE {
         dcat:keyword ?keyword ;
         niq:model ?model .
     }
-GROUP BY ?title
+GROUP BY ?uri

--- a/niquery/sparql/nidm-descriptor-database-summary-must.rq
+++ b/niquery/sparql/nidm-descriptor-database-summary-must.rq
@@ -12,6 +12,8 @@ WHERE {
          dct:title ?title ;
          dct:description ?description ;
          dct:publisher ?publisher .
-    OPTIONAL{ ?uri dct:isVersionOf ?isVersionOf . }
+    OPTIONAL{ ?uri dct:isVersionOf ?isVersionOf . } # required at the version level
+    FILTER (!bound(?isVersionOf))
+    OPTIONAL{ ?uri dct:format ?format . } # required at the distribution level
     FILTER (!bound(?isVersionOf))
 }

--- a/niquery/sparql/nidm-descriptor-database-summary-must.rq
+++ b/niquery/sparql/nidm-descriptor-database-summary-must.rq
@@ -6,12 +6,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX nidm: <http://incf.org/ns/nidash/nidm#>
 PREFIX niq: <http://purl.org/niquery#>
 
-SELECT DISTINCT ?uri ?type ?title ?description ?publisher
+SELECT DISTINCT ?uri ?type ?title ?description ?publisher ?hasPart
 WHERE {
     ?uri a ?type ;
          dct:title ?title ;
          dct:description ?description ;
-         dct:publisher ?publisher .
+         dct:publisher ?publisher ;
+         dct:hasPart ?hasPart .
     OPTIONAL{ ?uri dct:isVersionOf ?isVersionOf . } # required at the version level
     FILTER (!bound(?isVersionOf))
     OPTIONAL{ ?uri dct:format ?format . } # required at the distribution level

--- a/tests/data/nidm-descriptor.ttl
+++ b/tests/data/nidm-descriptor.ttl
@@ -19,16 +19,16 @@
 # Database summary-level Description
 :database
     a dctypes:Dataset ;
-    dct:title "Database"@en ;
+    dct:title "Database Summary Title"@en ;
     dct:identifier "database"@en ;
-    dct:description "A database."@en ;
+    dct:description "Database summary-level description."@en ;
     dct:accrualPeriodicity freq:continuous ;
-    dct:alternative "OpenfMRI"@en ;
+    dct:alternative "Database"@en ;
     dct:hasPart :project ;
     dct:language <http://lexvo.org/id/iso639-3/en> ;
     dct:license <http://www.opendatacommons.org/licenses/pddl/1.0/> ;
     dct:publisher <https://publisher.org> ;
-    dct:rights """Rights.""" ;
+    dct:rights "Rights." ;
     dct:source <https://database.com> ;
     idot:accessPattern <https://openfmri.org/data-sets> ;
     idot:alternatePrefix "db" ;
@@ -43,9 +43,9 @@
 # Project summary-level description.
 :project
     a dctypes:Dataset ;
-    dct:title "Project Title"@en ;
+    dct:title "Project Summary Title"@en ;
     dct:identifier "db001"@en ;
-    dct:description "Project Description."@en ;
+    dct:description "Project summary-level description."@en ;
     dcat:accessURL <http://database.com/project> ;
     pav:hasCurrentVersion :project-1.0.0 ;
     dct:license <http://www.opendatacommons.org/licenses/pddl/1.0/> ;
@@ -57,7 +57,7 @@
 :project-1.0.0
     a dctypes:Dataset ;
     dct:title "Project Version Title"@en ;
-    dct:description "Project version description."@en ;
+    dct:description "Project version-level description."@en ;
     dct:license <http://www.opendatacommons.org/licenses/pddl/1.0/> ;
     dct:creator <http://database.com> ;
     dct:publisher <http://database.com> ;

--- a/tests/test_nidm-descriptor.py
+++ b/tests/test_nidm-descriptor.py
@@ -1,23 +1,36 @@
 __author__ = 'Nolan Nichols <http://orcid.org/0000-0003-1099-3328>'
 
 import os
+import urlparse
 import unittest
 
 import niquery as niq
 
 
 class DescriptorCase(unittest.TestCase):
+    """
+    NIDM Dataset Descriptor Validation
+    """
     def setUp(self):
         self.turtle = os.path.join(os.path.dirname(__file__), 'data', 'nidm-descriptor.ttl')
-        self.query = niq.SelectQuery()
+        self.select = niq.SelectQuery()
 
-    def test_summary_must(self):
+    def test_project_summary_must(self):
         """
-        NIDM Descriptors MUST return one record the following elements to be a valid summary level description.
+        Project Summary-level description that MUST be present.
         """
-        os.path.join(os.path.dirname(__file__), '..', 'sparql')
-
-        self.assertEqual(True, True)
+        test_query = 'nidm-descriptor-database-summary-must.rq'
+        test_filter = self.select.sparql_meta.downloadURL.str.contains(test_query)
+        test_record = self.select.sparql_meta[test_filter]
+        idx = test_record.index.to_native_types()[0]
+        result = self.select.execute(idx, turtle_file=self.turtle)
+        # check that each of the required elements are present
+        self.assertEqual(urlparse.urlparse(result.uri[0]).fragment, "database")
+        self.assertEqual(result.title[0], "Database Summary Title")
+        self.assertEqual(result.description[0], "Database summary-level description.")
+        self.assertEqual(result.type[0], "http://purl.org/dc/dcmitype/Dataset")
+        self.assertEqual(result.publisher[0],"https://publisher.org")
+        self.assertEqual(urlparse.urlparse(result.hasPart[0]).fragment, "project")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
First shot at creating a test using a sparql query to validate that the required "MUST" attributes are present in a NIDM Dataset Descriptor.

@satra, could you take a quick look at this test and see if it makes sense. Feedback also appreciated on how I've implemented query.py and utils.py. Need to add docs, but here is an example session:

```
In [1]: import niquery as niq
In [2]: select = niq.SelectQuery()
In [3]: select.sparql_meta.title
Out[3]:
0                     Select All Contrasts
1                     Select All Summaries
2                       Select All Studies
3                 Select All Distributions
4                       Select All Queries
5    NIDM Dataset Descriptor Summary-level
6                      Select All Projects
7                      Select All Versions
8                  Select All Acquisitions
Name: title, dtype: object
In [4]: result = select.execute(5, turtle_file='/Users/nolan/Repos/niquery/tests/data/nidm-descriptor.ttl')
In [5]: result.keys()
Out[5]: Index([u'uri', u'type', u'title', u'description', u'publisher', u'hasPart'], dtype='object')
```
